### PR TITLE
Add methods `start` and `end` (equivalent to `ops::Range` fields)

### DIFF
--- a/src/space.rs
+++ b/src/space.rs
@@ -45,6 +45,25 @@ impl<I> Space<I> {
     }
 }
 
+impl<I: Interpolate + Copy> Space<I> {
+    /// Return the lower bound of the space.
+    ///
+    /// Note: the value returned by this method is unspecified after
+    /// the range has been iterated to exhaustion.
+    pub fn start(&self) -> I::Item {
+        self.interpolate.interpolate(self.range.start)
+    }
+
+    /// Returns the upper bound of the space (if inclusive, it is the
+    /// last element of the iterator).
+    ///
+    /// Note: the value returned by this method is unspecified after
+    /// the range has been iterated to exhaustion.
+    pub fn end(&self) -> I::Item {
+        self.interpolate.interpolate(self.range.end)
+    }
+}
+
 impl<I: Interpolate + Copy> Iterator for Space<I> {
     type Item = I::Item;
 


### PR DESCRIPTION
Accessing `start` and `end` values makes this more versatile as one can use it to specify a subdivision of an interval even if one does not consume it though an iterator.