### PR TITLE
Add a bounds method to `Space` returning `(Bounds<T>, Bounds<T>)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["algorithms", "rust-patterns", "no-std"]
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 # array_iter_tools = "0.2.0"
 array-bin-ops = "0.1.6"
+strength_reduce = "0.2.4"
 
 [features]
 trusted_len = []

--- a/README.md
+++ b/README.md
@@ -132,38 +132,4 @@ assert!(zip_eq(it, expected).all(|(x, y)| (x-y).abs() < 1e-10));
 
 ## Alternatives
 
-There is already a project called [`itertools-num`](https://docs.rs/itertools-num/0.1.3/itertools_num/) which has quite a few downloads but it
-isn't optimised for speed or flexibility.
-
-(try this benchmark for yourself: clone the repo and run `cargo bench --bench "linspace" --all-features`)
-
-```
-LinSpace/linspace [1.0, 3.0] x100 (iter-num-tools)
-                        time:   [65.311 ns 65.579 ns 65.898 ns]
-LinSpace/linspace [1.0, 3.0] x100 (std)
-                        time:   [67.545 ns 67.762 ns 68.047 ns]
-LinSpace/linspace [1.0, 3.0] x100 (itertools-num)
-                        time:   [117.05 ns 117.59 ns 118.23 ns]
-```
-
-```rust
-fn bench(i: impl Iterator<Item=f64>) -> Vec<f64> {
-    black_box(i.map(|x| x * 2.0).collect())
-}
-
-// first benchmark (fastest)
-bench(iter_num_tools::lin_space(1.0..=3.0, 100));
-
-// second benchmark
-fn lin_space_std(start: f64, end: f64, steps: usize) -> impl Iterator<Item = f64> {
-    let len = end - start;
-    let step = len / steps as f64;
-    (0..=steps).map(move |i| start + i as f64 * step)
-}
-bench(lin_space_std(1.0, 3.0, 100));
-
-// third benchmark (slowest)
-bench(itertools_num::linspace(1.0, 3.0, 100));
-```
-
-It also does not provide any other utilities. Only `linspace` (inclusive) and a 'Cumulative sum' iterator adaptor.
+There is already a project called [`itertools-num`](https://docs.rs/itertools-num/0.1.3/itertools_num/) which has quite a few downloads but it only offers `linspace` (inclusive) and a 'cumulative sum' iterator adaptor.

--- a/benches/arange.rs
+++ b/benches/arange.rs
@@ -2,22 +2,23 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use iter_num_tools::arange;
 
 fn bench(i: impl Iterator<Item = f64>) -> f64 {
-    black_box(black_box(i).sum())
+    black_box(i.sum())
 }
 
 pub fn bench_arange(c: &mut Criterion) {
     let mut group = c.benchmark_group("Arange");
 
     group.bench_function("arange [0,200) steps 1.0", |b| {
-        b.iter(|| bench(arange(0.0..200.0, 1.0)))
+        b.iter(|| bench(arange(black_box(0.0..200.0), black_box(1.0))))
     });
 
     group.bench_function("arange [0,200) steps 1.0 std", |b| {
         b.iter(|| {
             let mut start = 0.0;
-            bench((0..200).map(|_| {
+            let step = black_box(1.0);
+            bench(black_box(0..200).map(|_| {
                 let result = start;
-                start += 1.0;
+                start += step;
                 result
             }))
         })

--- a/benches/gridspace.rs
+++ b/benches/gridspace.rs
@@ -2,14 +2,14 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use iter_num_tools::grid_space;
 
 fn bench(i: impl Iterator<Item = [f64; 2]>) -> f64 {
-    black_box(black_box(i).map(|[a, b]| a + b).sum())
+    black_box(i.map(|[a, b]| a + b).sum())
 }
 
 pub fn bench_grid_space(c: &mut Criterion) {
     let mut group = c.benchmark_group("GridSpace");
 
     group.bench_function("gridspace [1.0, 100.0] x200 (iter-num-tools)", |b| {
-        b.iter(|| bench(grid_space([1.0, 1.0]..=[100.0, 100.0], 200)))
+        b.iter(|| bench(grid_space(black_box([1.0, 1.0]..=[100.0, 100.0]), black_box(200))))
     });
 
     group.finish();

--- a/benches/linspace.rs
+++ b/benches/linspace.rs
@@ -2,28 +2,40 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use iter_num_tools::lin_space;
 
 fn bench(i: impl Iterator<Item = f64>) -> f64 {
-    black_box(black_box(i).sum())
+    black_box(i.sum())
 }
 
 fn lin_space_std(start: f64, end: f64, steps: usize) -> impl Iterator<Item = f64> {
     let len = end - start;
-    let step = len / steps as f64;
-    (0..=steps).map(move |i| start + i as f64 * step)
+    let step = len / (steps - 1) as f64;
+    (0..steps).map(move |i| start + i as f64 * step)
 }
 
 pub fn bench_lin_space(c: &mut Criterion) {
     let mut group = c.benchmark_group("LinSpace");
 
     group.bench_function("linspace [1.0, 100.0] x200 (iter-num-tools)", |b| {
-        b.iter(|| bench(lin_space(1.0..=100.0, 200)))
+        b.iter(|| bench(lin_space(black_box(1.0..=100.0), black_box(200))))
     });
 
     group.bench_function("linspace [1.0, 100.0] x200 (std)", |b| {
-        b.iter(|| bench(lin_space_std(1.0, 100.0, 200)))
+        b.iter(|| {
+            bench(lin_space_std(
+                black_box(1.0),
+                black_box(100.0),
+                black_box(200),
+            ))
+        })
     });
 
     group.bench_function("linspace [1.0, 100.0] x200 (itertools-num)", |b| {
-        b.iter(|| bench(itertools_num::linspace(1.0, 100.0, 200)))
+        b.iter(|| {
+            bench(itertools_num::linspace(
+                black_box(1.0),
+                black_box(100.0),
+                black_box(200),
+            ))
+        })
     });
 
     group.finish();

--- a/benches/logspace.rs
+++ b/benches/logspace.rs
@@ -7,11 +7,19 @@ fn bench(i: impl Iterator<Item = f32>) -> f32 {
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("logspace [1,1000) x200", |b| {
-        b.iter(|| bench(log_space(1.0..1000.0, 200)))
+        b.iter(|| bench(log_space(black_box(1.0..1000.0), black_box(200))))
     });
 
     c.bench_function("logspace [1,1000) x200 std", |b| {
-        b.iter(|| bench(lin_space(1.0f32.log2()..1000.0f32.log2(), 200).map(f32::exp2)))
+        b.iter(|| {
+            bench(
+                lin_space(
+                    black_box(1.0f32).log2()..black_box(1000.0f32).log2(),
+                    black_box(200),
+                )
+                .map(f32::exp2),
+            )
+        })
     });
 }
 

--- a/src/arange.rs
+++ b/src/arange.rs
@@ -3,10 +3,10 @@ use core::ops::Range;
 use num_traits::real::Real;
 
 /// [`Iterator`] returned by [`arange`]
-pub type Arange<T> = LinSpace<T>;
+pub type Arange<T, R> = LinSpace<T, R>;
 
 /// [`IntoIterator`] returned by [`ToArange::into_arange`]
-pub type IntoArange<T> = IntoLinSpace<T>;
+pub type IntoArange<T, R> = IntoLinSpace<T, R>;
 
 /// Create a new iterator over the range, stepping by `step` each time
 /// This allows you to create simple float iterators
@@ -17,7 +17,7 @@ pub type IntoArange<T> = IntoLinSpace<T>;
 /// let it = arange(0.0..2.0, 0.5);
 /// assert!(it.eq(vec![0.0, 0.5, 1.0, 1.5]));
 /// ```
-pub fn arange<R, F>(range: R, step: F) -> Arange<R::Item>
+pub fn arange<R, F>(range: R, step: F) -> Arange<R::Item, <R::Range as IntoIterator>::IntoIter>
 where
     R: ToArange<F>,
 {
@@ -28,30 +28,46 @@ where
 pub trait ToArange<S> {
     /// The item that this is a arange space over
     type Item;
+
+    /// The type of range this space spans - eg inclusive or exclusive
+    type Range: IntoIterator<Item = usize>;
+
     /// Create the arange space
-    fn into_arange(self, step: S) -> IntoArange<Self::Item>;
+    fn into_arange(self, step: S) -> IntoArange<Self::Item, Self::Range>;
 }
 
 impl<F: Real> ToArange<F> for Range<F> {
     type Item = F;
 
-    fn into_arange(self, step: F) -> IntoArange<Self::Item> {
+    type Range = Range<usize>;
+
+    fn into_arange(self, step: F) -> IntoArange<Self::Item, Self::Range> {
         let Range { start, end } = self;
 
         IntoArange::new(
-            ((end - start) / step).ceil().to_usize().unwrap(),
             LinearInterpolation { start, step },
+            0..((end - start) / step).ceil().to_usize().unwrap(),
         )
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use core::ops::Bound;
+
     use super::*;
 
     #[test]
     fn test_arange() {
         let it = arange(0.0..2.0, 0.5);
         assert!(it.eq(vec![0.0, 0.5, 1.0, 1.5]));
+    }
+
+    #[test]
+    fn test_arange_bounds() {
+        assert_eq!(
+            arange(0.0..2.0, 0.5).bounds(),
+            (Bound::Included(0.0), Bound::Excluded(2.0))
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub use logspace::{log_space, IntoLogSpace, LogSpace, ToLogSpace};
 
 #[cfg(test)]
 #[track_caller]
-pub fn check_double_ended_iter<T: PartialEq + core::fmt::Debug, const N: usize>(
+fn check_double_ended_iter<T: PartialEq + core::fmt::Debug, const N: usize>(
     i: impl DoubleEndedIterator<Item = T> + Clone,
     mut expected: [T; N],
 ) {

--- a/src/logspace.rs
+++ b/src/logspace.rs
@@ -23,7 +23,10 @@ use crate::space::{Interpolate, IntoSpace, Space};
 /// // all approx equal
 /// assert!(zip_eq(it, expected).all(|(x, y)| (x-y).abs() < 1e-10));
 /// ```
-pub fn log_space<R>(range: R, steps: usize) -> LogSpace<R::Item>
+pub fn log_space<R>(
+    range: R,
+    steps: usize,
+) -> LogSpace<R::Item, <R::Range as IntoIterator>::IntoIter>
 where
     R: ToLogSpace,
 {
@@ -40,8 +43,12 @@ pub struct LogarithmicInterpolation<T> {
 pub trait ToLogSpace {
     /// The item that this is a logarithmic space over
     type Item;
+
+    /// The type of range this space spans - eg inclusive or exclusive
+    type Range: IntoIterator<Item = usize>;
+
     /// Create the log space
-    fn into_log_space(self, step: usize) -> IntoLogSpace<Self::Item>;
+    fn into_log_space(self, step: usize) -> IntoLogSpace<Self::Item, Self::Range>;
 }
 
 impl<T: Real> Interpolate for LogarithmicInterpolation<T> {
@@ -54,31 +61,35 @@ impl<T: Real> Interpolate for LogarithmicInterpolation<T> {
 
 impl<T: Real + FromPrimitive> ToLogSpace for Range<T> {
     type Item = T;
+    type Range = Range<usize>;
 
-    fn into_log_space(self, steps: usize) -> IntoLogSpace<Self::Item> {
+    fn into_log_space(self, steps: usize) -> IntoLogSpace<Self::Item, Self::Range> {
         let Range { start, end } = self;
         let step = (end / start).powf(T::from_usize(steps).unwrap().recip());
-        IntoLogSpace::new(steps, LogarithmicInterpolation { start, step })
+        IntoLogSpace::new_exclusive(steps, LogarithmicInterpolation { start, step })
     }
 }
 
 impl<T: Real + FromPrimitive> ToLogSpace for RangeInclusive<T> {
     type Item = T;
+    type Range = RangeInclusive<usize>;
 
-    fn into_log_space(self, steps: usize) -> IntoLogSpace<Self::Item> {
+    fn into_log_space(self, steps: usize) -> IntoLogSpace<Self::Item, Self::Range> {
         let (start, end) = self.into_inner();
         let step = (end / start).powf(T::from_usize(steps - 1).unwrap().recip());
-        IntoLogSpace::new(steps, LogarithmicInterpolation { start, step })
+        IntoLogSpace::new_inclusive(steps, LogarithmicInterpolation { start, step })
     }
 }
 
 /// [`Iterator`] returned by [`log_space`]
-pub type LogSpace<T> = Space<LogarithmicInterpolation<T>>;
+pub type LogSpace<T, R> = Space<LogarithmicInterpolation<T>, R>;
 /// [`IntoIterator`] returned by [`ToLogSpace::into_log_space`]
-pub type IntoLogSpace<T> = IntoSpace<LogarithmicInterpolation<T>>;
+pub type IntoLogSpace<T, R> = IntoSpace<LogarithmicInterpolation<T>, R>;
 
 #[cfg(test)]
 mod tests {
+    use core::ops::Bound;
+
     use super::*;
 
     use itertools::zip_eq;
@@ -115,15 +126,41 @@ mod tests {
         assert_eq!(it.size_hint(), (expected_len, Some(expected_len)));
 
         while expected_len > 0 {
-            assert_eq!(it.len(), expected_len);
+            assert_eq!(it.size_hint(), (expected_len, Some(expected_len)));
             it.next();
             expected_len -= 1;
 
-            assert_eq!(it.len(), expected_len);
+            assert_eq!(it.size_hint(), (expected_len, Some(expected_len)));
             it.next_back();
             expected_len -= 1;
         }
 
-        assert_eq!(it.len(), expected_len);
+        assert_eq!(it.size_hint(), (expected_len, Some(expected_len)));
+    }
+
+    #[test]
+    fn test_log_inclusive_bounds() {
+        let (start, end) = log_space(1.0..=1000.0, 4).bounds();
+        assert!(
+            matches!(start, Bound::Included(x) if (x - 1.0).abs() < 1e-10),
+            "{start:?}"
+        );
+        assert!(
+            matches!(end, Bound::Included(x) if (x - 1000.0).abs() < 1e-10),
+            "{end:?}"
+        );
+    }
+
+    #[test]
+    fn test_log_exclusive_bounds() {
+        let (start, end) = log_space(1.0..1000.0, 3).bounds();
+        assert!(
+            matches!(start, Bound::Included(x) if (x - 1.0).abs() < 1e-10),
+            "{start:?}"
+        );
+        assert!(
+            matches!(end, Bound::Excluded(x) if (x - 1000.0).abs() < 1e-10),
+            "{end:?}"
+        );
     }
 }

--- a/src/space.rs
+++ b/src/space.rs
@@ -22,6 +22,13 @@ impl<I, R> IntoSpace<I, R> {
     pub fn new(interpolate: I, range: R) -> Self {
         IntoSpace { interpolate, range }
     }
+
+    pub(crate) fn map<J>(self, f: impl FnOnce(I) -> J) -> IntoSpace<J, R> {
+        IntoSpace {
+            interpolate: f(self.interpolate),
+            range: self.range,
+        }
+    }
 }
 
 impl<I> IntoSpace<I, Range<usize>> {


### PR DESCRIPTION
This bounds method allows getting the start/end of the iter space.

Problem 1:
To get inclusive/exclusive bounds info, I had to update `Space` to be generic over the size range it stores. This required changing a lot of code.

Problem 2:
The way I encoded the grid-space interpolation was using modular arithmetic. This means at the end it cycles back to the beginning. because of this I had to add a hack to interpolate the exclusive end bounds.

Problem 0:
I realised that grid space impl was slow. Using strength-reduce speeds up the div/mod massively.